### PR TITLE
Rename the CRC variable to lower case letters

### DIFF
--- a/src/Bridge.cpp
+++ b/src/Bridge.cpp
@@ -55,7 +55,7 @@ void BridgeClass::begin() {
     delay(500);
     dropAll();
 
-    // Reset the bridge to check if it is running
+    // Reset the brigde to check if it is running
     uint8_t cmd[] = {'X', 'X', '1', '0', '0'};
     uint8_t res[4];
     max_retries = 50;
@@ -138,31 +138,31 @@ unsigned int BridgeClass::get(const char *key, uint8_t *value, unsigned int maxl
 #include <util/crc16.h>
 #else
 // Generic implementation for non-AVR architectures
-uint16_t _crc_ccitt_update(uint16_t crc, uint8_t data)
+uint16_t _crc_ccitt_update(uint16_t _crc, uint8_t _data)
 {
-  data ^= crc & 0xff;
-  data ^= data << 4;
-  return ((((uint16_t)data << 8) | ((crc >> 8) & 0xff)) ^
-          (uint8_t)(data >> 4) ^
-          ((uint16_t)data << 3));
+  _data ^= _crc & 0xff;
+  _data ^= _data << 4;
+  return ((((uint16_t)_data << 8) | ((_crc >> 8) & 0xff)) ^
+          (uint8_t)(_data >> 4) ^
+          ((uint16_t)_data << 3));
 }
 #endif
 
 void BridgeClass::crcUpdate(uint8_t c) {
-  CRC = _crc_ccitt_update(CRC, c);
+  crc = _crc_ccitt_update(crc, c);
 }
 
 void BridgeClass::crcReset() {
-  CRC = 0xFFFF;
+  crc = 0xFFFF;
 }
 
 void BridgeClass::crcWrite() {
-  stream.write((char)(CRC >> 8));
-  stream.write((char)(CRC & 0xFF));
+  stream.write((char)(crc >> 8));
+  stream.write((char)(crc & 0xFF));
 }
 
-bool BridgeClass::crcCheck(uint16_t _CRC) {
-  return CRC == _CRC;
+bool BridgeClass::crcCheck(uint16_t _crc) {
+  return crc == _crc;
 }
 
 uint16_t BridgeClass::transfer(const uint8_t *buff1, uint16_t len1,
@@ -309,3 +309,4 @@ SerialBridgeClass Bridge(Serial1);
 #else
 SerialBridgeClass Bridge(Serial);
 #endif
+

--- a/src/Bridge.h
+++ b/src/Bridge.h
@@ -44,7 +44,7 @@ class BridgeClass {
       return get(key, reinterpret_cast<uint8_t *>(value), maxlen);
     }
 
-    // Transfer a frame (with error correction and response)
+    // Trasnfer a frame (with error correction and response)
     uint16_t transfer(const uint8_t *buff1, uint16_t len1,
                       const uint8_t *buff2, uint16_t len2,
                       const uint8_t *buff3, uint16_t len3,
@@ -83,8 +83,8 @@ class BridgeClass {
     void crcUpdate(uint8_t c);
     void crcReset();
     void crcWrite();
-    bool crcCheck(uint16_t _CRC);
-    uint16_t CRC;
+    bool crcCheck(uint16_t _crc);
+    uint16_t crc;
 
   private:
     static const char CTRL_C = 3;


### PR DESCRIPTION
CRC variable in upper case makes conflicts with defines in other libraries/frameworks (e.g. Arduino-SMT32)